### PR TITLE
Add indexes field

### DIFF
--- a/internal/loader.go
+++ b/internal/loader.go
@@ -79,6 +79,8 @@ func (tl *TypeLoader) LoadSchema(args *ArgType) (map[string]*Type, map[string]*I
 		return nil, nil, err
 	}
 
+	setIndexesToTables(tableMap, ixMap)
+
 	return tableMap, ixMap, nil
 }
 
@@ -342,4 +344,15 @@ func (tl *TypeLoader) LoadCustomTypes(path string) error {
 	tl.CustomTypes = &ctypes
 
 	return nil
+}
+
+func setIndexesToTables(tableMap map[string]*Type, ixMap map[string]*Index) {
+	for tbl, t := range tableMap {
+		ixPrefix := fmt.Sprintf("%s_", tbl)
+		for ixName, ix := range ixMap {
+			if strings.HasPrefix(ixName, ixPrefix) {
+				t.Indexes = append(t.Indexes, ix)
+			}
+		}
+	}
 }

--- a/internal/loader_test.go
+++ b/internal/loader_test.go
@@ -1,0 +1,78 @@
+package internal
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_setIndexesToTables(t *testing.T) {
+	tests := []struct {
+		table  map[string]*Type
+		ix     map[string]*Index
+		result map[string]int
+	}{
+		{
+			table: map[string]*Type{
+				"TableA": &Type{
+					Indexes: []*Index{},
+				},
+			},
+			ix: map[string]*Index{
+				"TableA_Index1": &Index{},
+				"TableA_Index2": &Index{},
+			},
+			result: map[string]int{
+				"TableA": 2,
+			},
+		},
+		{
+			table: map[string]*Type{
+				"TableA": &Type{
+					Indexes: []*Index{},
+				},
+				"TableB": &Type{
+					Indexes: []*Index{},
+				},
+			},
+			ix: map[string]*Index{
+				"TableA_Index1": &Index{},
+				"TableA_Index2": &Index{},
+			},
+			result: map[string]int{
+				"TableA": 2,
+				"TableB": 0,
+			},
+		},
+		{
+			table: map[string]*Type{
+				"TableA": &Type{
+					Indexes: []*Index{},
+				},
+				"TableB": &Type{
+					Indexes: []*Index{},
+				},
+			},
+			ix: map[string]*Index{
+				"TableA_Index1":               &Index{},
+				"TableA_Index2":               &Index{},
+				"TableB_Index1":               &Index{},
+				"TableB_Index2forTableA_Hoge": &Index{},
+			},
+			result: map[string]int{
+				"TableA": 2,
+				"TableB": 2,
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("case:%d", i), func(t *testing.T) {
+			setIndexesToTables(tt.table, tt.ix)
+			for k, v := range tt.table {
+				if len(v.Indexes) != tt.result[k] {
+					t.Errorf("error. want:%d got:%d", tt.result[k], len(v.Indexes))
+				}
+			}
+		})
+	}
+}

--- a/internal/types.go
+++ b/internal/types.go
@@ -39,6 +39,7 @@ type Type struct {
 	PrimaryKeyFields []*Field
 	Fields           []*Field
 	Table            *models.Table
+	Indexes          []*Index
 }
 
 // Index is a template item for a index into a table.


### PR DESCRIPTION
Hello!
Thank you awesome software.

I want to create interface struct by yo.

e.g)

```go
type Test interface {
    // by types.go.tpl
    Update()
    Insert()
    // by index.go.tpl
    FindTestByHoge()
    FindTestByFuga()
}
```

but yo renders index.go.tpl each index so I can't render correct format

e.g)

```go
type Test interface {
    // by types.go.tpl
    Update()
    Insert()
    // by index.go.tpl
    FindTestByHoge()
}
    // by index.go.tpl    
    FindTestByFuga()
}
```
So I added `Indexes []*internal.Index` field to `internal.Type` 

ref: https://github.com/cloudspannerecosystem/yo/issues/31

___

> Please read the contribution guidelines and the CLA carefully before
> submitting your pull request.
>
> https://cla.developers.google.com/

I agreed CLA.


