### PR TITLE
Fix vanity import path

### DIFF
--- a/cmd/create_template.go
+++ b/cmd/create_template.go
@@ -21,7 +21,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"go.mercari.io/yo/generator"
+	"github.com/cloudspannerecosystem/yo/generator"
 )
 
 var createTemplatePath string

--- a/cmd/create_template.go
+++ b/cmd/create_template.go
@@ -21,6 +21,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
 	"github.com/cloudspannerecosystem/yo/generator"
 )
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/cloudspannerecosystem/yo/generator"
 	"github.com/cloudspannerecosystem/yo/internal"
 	"github.com/cloudspannerecosystem/yo/loaders"

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"go.mercari.io/yo/generator"
-	"go.mercari.io/yo/internal"
-	"go.mercari.io/yo/loaders"
+	"github.com/cloudspannerecosystem/yo/generator"
+	"github.com/cloudspannerecosystem/yo/internal"
+	"github.com/cloudspannerecosystem/yo/loaders"
 )
 
 var (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,9 +28,9 @@ import (
 
 	"cloud.google.com/go/spanner"
 	"github.com/spf13/cobra"
-	"go.mercari.io/yo/generator"
-	"go.mercari.io/yo/internal"
-	"go.mercari.io/yo/loaders"
+	"github.com/cloudspannerecosystem/yo/generator"
+	"github.com/cloudspannerecosystem/yo/internal"
+	"github.com/cloudspannerecosystem/yo/loaders"
 )
 
 const (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	"github.com/spf13/cobra"
+
 	"github.com/cloudspannerecosystem/yo/generator"
 	"github.com/cloudspannerecosystem/yo/internal"
 	"github.com/cloudspannerecosystem/yo/loaders"

--- a/doc.go
+++ b/doc.go
@@ -17,4 +17,4 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-package main // import "go.mercari.io/yo"
+package main // import "github.com/cloudspannerecosystem/yo"

--- a/generator/copy.go
+++ b/generator/copy.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"go.mercari.io/yo/tplbin"
+	"github.com/cloudspannerecosystem/yo/tplbin"
 )
 
 // CopyDefaultTemplates copies default templete files to dir.

--- a/generator/doc.go
+++ b/generator/doc.go
@@ -17,4 +17,4 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-package generator // import "go.mercari.io/yo/generator"
+package generator // import "github.com/cloudspannerecosystem/yo/generator"

--- a/generator/funcs.go
+++ b/generator/funcs.go
@@ -25,8 +25,8 @@ import (
 	"text/template"
 
 	"github.com/knq/snaker"
-	"go.mercari.io/yo/internal"
-	"go.mercari.io/yo/models"
+	"github.com/cloudspannerecosystem/yo/internal"
+	"github.com/cloudspannerecosystem/yo/models"
 )
 
 // newTemplateFuncs returns a set of template funcs bound to the supplied args.

--- a/generator/funcs.go
+++ b/generator/funcs.go
@@ -25,6 +25,7 @@ import (
 	"text/template"
 
 	"github.com/knq/snaker"
+
 	"github.com/cloudspannerecosystem/yo/internal"
 	"github.com/cloudspannerecosystem/yo/models"
 )

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -31,8 +31,8 @@ import (
 	"strings"
 	"text/template"
 
-	"go.mercari.io/yo/internal"
-	templates "go.mercari.io/yo/tplbin"
+	"github.com/cloudspannerecosystem/yo/internal"
+	templates "github.com/cloudspannerecosystem/yo/tplbin"
 )
 
 // Loader is the common interface for database drivers that can generate code

--- a/generator/templates.go
+++ b/generator/templates.go
@@ -23,7 +23,7 @@ import (
 	"io"
 	"text/template"
 
-	"go.mercari.io/yo/internal"
+	"github.com/cloudspannerecosystem/yo/internal"
 )
 
 // TemplateType represents a template type.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.mercari.io/yo
+module github.com/cloudspannerecosystem/yo
 
 go 1.13
 

--- a/internal/doc.go
+++ b/internal/doc.go
@@ -17,4 +17,4 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-package internal // import "go.mercari.io/yo/internal"
+package internal // import "github.com/cloudspannerecosystem/yo/internal"

--- a/internal/loader.go
+++ b/internal/loader.go
@@ -25,8 +25,9 @@ import (
 	"strings"
 
 	"github.com/knq/snaker"
-	"github.com/cloudspannerecosystem/yo/models"
 	"gopkg.in/yaml.v2"
+
+	"github.com/cloudspannerecosystem/yo/models"
 )
 
 type loaderImpl interface {

--- a/internal/loader.go
+++ b/internal/loader.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/knq/snaker"
-	"go.mercari.io/yo/models"
+	"github.com/cloudspannerecosystem/yo/models"
 	"gopkg.in/yaml.v2"
 )
 

--- a/internal/types.go
+++ b/internal/types.go
@@ -19,7 +19,7 @@
 
 package internal
 
-import "go.mercari.io/yo/models"
+import "github.com/cloudspannerecosystem/yo/models"
 
 // Field contains field information.
 type Field struct {

--- a/loaders/doc.go
+++ b/loaders/doc.go
@@ -17,4 +17,4 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-package loaders // import "go.mercari.io/yo/loaders"
+package loaders // import "github.com/cloudspannerecosystem/yo/loaders"

--- a/loaders/parser.go
+++ b/loaders/parser.go
@@ -27,7 +27,7 @@ import (
 	"github.com/MakeNowJust/memefish/pkg/ast"
 	"github.com/MakeNowJust/memefish/pkg/parser"
 	"github.com/MakeNowJust/memefish/pkg/token"
-	"go.mercari.io/yo/models"
+	"github.com/cloudspannerecosystem/yo/models"
 )
 
 func NewSpannerLoaderFromDDL(fpath string) (*SpannerLoaderFromDDL, error) {

--- a/loaders/parser.go
+++ b/loaders/parser.go
@@ -27,6 +27,7 @@ import (
 	"github.com/MakeNowJust/memefish/pkg/ast"
 	"github.com/MakeNowJust/memefish/pkg/parser"
 	"github.com/MakeNowJust/memefish/pkg/token"
+
 	"github.com/cloudspannerecosystem/yo/models"
 )
 

--- a/loaders/spanner.go
+++ b/loaders/spanner.go
@@ -28,7 +28,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	"github.com/knq/snaker"
-	"go.mercari.io/yo/models"
+	"github.com/cloudspannerecosystem/yo/models"
 	"google.golang.org/api/iterator"
 )
 

--- a/loaders/spanner.go
+++ b/loaders/spanner.go
@@ -28,8 +28,9 @@ import (
 
 	"cloud.google.com/go/spanner"
 	"github.com/knq/snaker"
-	"github.com/cloudspannerecosystem/yo/models"
 	"google.golang.org/api/iterator"
+
+	"github.com/cloudspannerecosystem/yo/models"
 )
 
 func NewSpannerLoader(client *spanner.Client) *SpannerLoader {

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"go.mercari.io/yo/cmd"
+	"github.com/cloudspannerecosystem/yo/cmd"
 )
 
 func main() {

--- a/models/doc.go
+++ b/models/doc.go
@@ -17,4 +17,4 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-package models // import "go.mercari.io/yo/models"
+package models // import "github.com/cloudspannerecosystem/yo/models"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -31,11 +31,12 @@ import (
 	"cloud.google.com/go/spanner"
 	dbadmin "cloud.google.com/go/spanner/admin/database/apiv1"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/cloudspannerecosystem/yo/test/testmodels/customtypes"
 	models "github.com/cloudspannerecosystem/yo/test/testmodels/default"
 	"github.com/cloudspannerecosystem/yo/test/testutil"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 var (

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -31,9 +31,9 @@ import (
 	"cloud.google.com/go/spanner"
 	dbadmin "cloud.google.com/go/spanner/admin/database/apiv1"
 	"github.com/google/go-cmp/cmp"
-	"go.mercari.io/yo/test/testmodels/customtypes"
-	models "go.mercari.io/yo/test/testmodels/default"
-	"go.mercari.io/yo/test/testutil"
+	"github.com/cloudspannerecosystem/yo/test/testmodels/customtypes"
+	models "github.com/cloudspannerecosystem/yo/test/testmodels/default"
+	"github.com/cloudspannerecosystem/yo/test/testutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/tplbin/doc.go
+++ b/tplbin/doc.go
@@ -17,4 +17,4 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-package tplbin // import "go.mercari.io/yo/tplbin"
+package tplbin // import "github.com/cloudspannerecosystem/yo/tplbin"


### PR DESCRIPTION
Fix `go.mercari.io/yo` vanity import path to `github.com/cloudspannerecosystem/yo`.

Also, run `goimports -w -local github.com/cloudspannerecosystem/yo .`