### PR TITLE
Fix not to generate redundunt change logs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
       - name: Set up Go 1.13
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
#48
This PR fixes redundant change logs (including commits from old release) listed on a release page.