### PR TITLE
Fix import name to kenshaw

### DIFF
--- a/generator/funcs.go
+++ b/generator/funcs.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/knq/snaker"
+	"github.com/kenshaw/snaker"
 
 	"go.mercari.io/yo/internal"
 	"go.mercari.io/yo/models"

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/go-cmp v0.4.0
 	github.com/jessevdk/go-assets v0.0.0-20160921144138-4f4301a06e15
 	github.com/jinzhu/inflection v1.0.0
-	github.com/knq/snaker v0.0.0-20181215144011-2bc8a4db4687
+	github.com/kenshaw/snaker v0.1.0
 	github.com/mattn/go-sqlite3 v2.0.1+incompatible // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -182,14 +182,14 @@ github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q
 github.com/k0kubun/pp v1.3.1-0.20200204103551-99835366d1cc/go.mod h1:qK2ivXw91omfE1uXcpR5kWbAMZRdDOnGbqWlZ7reRFk=
 github.com/k0kubun/pp v3.0.2-0.20190719145753-b20d3da80efa+incompatible h1:46zqq9SllBiviBmvTmkM73qrMs0S9dEzJAr1XFnSid4=
 github.com/k0kubun/pp v3.0.2-0.20190719145753-b20d3da80efa+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
+github.com/kenshaw/snaker v0.1.0 h1:h6dvdkBw6Qe1ya/LE9kMa9Y8M3RSAhbELfirZHIFobU=
+github.com/kenshaw/snaker v0.1.0/go.mod h1:0xAAdPB2IwUAxxUZj5ZvPclku2HJBSB7TRcJxvhVwM8=
 github.com/kisielk/gotool v0.0.0-20161130080628-0de1eaf82fa3/go.mod h1:jxZFDH7ILpTPQTk+E2s+z4CUas9lVNjIuKR4c5/zKgM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
-github.com/knq/snaker v0.0.0-20181215144011-2bc8a4db4687 h1:ZrOZbqW7T2EgLd4soRATeSZrP3ijy2CgNFXG44cUuS8=
-github.com/knq/snaker v0.0.0-20181215144011-2bc8a4db4687/go.mod h1:f0Dmq8fkddh8nOsVabYmtOHHdxlq2q4X+LQ1xWQEdUU=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/internal/loader.go
+++ b/internal/loader.go
@@ -25,7 +25,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/knq/snaker"
+	"github.com/kenshaw/snaker"
 	"go.mercari.io/yo/models"
 	"gopkg.in/yaml.v2"
 )

--- a/internal/util.go
+++ b/internal/util.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/knq/snaker"
+	"github.com/kenshaw/snaker"
 )
 
 // reverseIndexRune finds the last rune r in s, returning -1 if not present.

--- a/loaders/spanner.go
+++ b/loaders/spanner.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/spanner"
-	"github.com/knq/snaker"
+	"github.com/kenshaw/snaker"
 	"go.mercari.io/yo/models"
 	"google.golang.org/api/iterator"
 )


### PR DESCRIPTION
## What
Fixed import name from `knq` to `kenshaw`.

## Why
When using the below command, `go get` does not succeed. 

```
$ go get -u go.mercari.io/yo
```
<img width="805" alt="スクリーンショット 2020-10-28 12 44 10" src="https://user-images.githubusercontent.com/39621165/97402578-19fef600-1936-11eb-8d51-35be1905c36b.png">

## Other
This is the first time for me to contribute to OSS.
Thank you for reviewing!

## Reference 
- https://github.com/knq/snaker
	- This link jumps the below link

- https://github.com/kenshaw/snaker
