### PR TITLE
test/testutil: add missing defer file.Close()

### DIFF
--- a/test/testutil/data.go
+++ b/test/testutil/data.go
@@ -224,6 +224,7 @@ func ApplyTestSchema(ctx context.Context, adminClient *dbadmin.DatabaseAdminClie
 	if err != nil {
 		return fmt.Errorf("scheme file cannot open: %v", err)
 	}
+	defer file.Close()
 
 	b, err := ioutil.ReadAll(file)
 	if err != nil {


### PR DESCRIPTION
test/testutil: add missing `defer file.Close()`.