### PR TITLE
Make 'yo generate' overwrite yo_db file

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -167,15 +167,10 @@ func (g *Generator) getFile(ds *basicDataSet, t *TBuf) (*os.File, error) {
 	// default open mode
 	mode := os.O_RDWR | os.O_CREATE | os.O_TRUNC
 
-	// stat file to determine if file already exists
+	// stat file to determine if file is a directory.
 	fi, err := os.Stat(filename)
 	if err == nil && fi.IsDir() {
 		return nil, errors.New("filename cannot be directory")
-	}
-
-	// skip
-	if t.TemplateType == YOTemplate && fi != nil {
-		return nil, nil
 	}
 
 	// open file
@@ -229,11 +224,6 @@ func (g *Generator) writeTypes(ds *basicDataSet) error {
 		f, err = g.getFile(ds, &t)
 		if err != nil {
 			return err
-		}
-
-		// should only be nil when type == yo
-		if f == nil {
-			continue
 		}
 
 		// write segment


### PR DESCRIPTION
`yo generate` does not overwrite `YOTemplate` (`yo_db`) file if the file already exists. This PR makes it overwrite `YOTemplate` file. I'm not sure why it currently skips writing `YOTemplate` file, but this change certainly makes it easier to update `yo_db.tpl` of a project.

Note that it always overwrites `YOTemplate` content if the single file option is enabled, because `Generator.files` already has the file pointer when it tries to get the file pointer to write the content.