### PR TITLE
Fix/use parseddls

### DIFF
--- a/internal/loader_test.go
+++ b/internal/loader_test.go
@@ -3,6 +3,8 @@ package internal
 import (
 	"fmt"
 	"testing"
+
+	"go.mercari.io/yo/models"
 )
 
 func Test_setIndexesToTables(t *testing.T) {
@@ -18,8 +20,20 @@ func Test_setIndexesToTables(t *testing.T) {
 				},
 			},
 			ix: map[string]*Index{
-				"TableA_Index1": &Index{},
-				"TableA_Index2": &Index{},
+				"TableA_Index1": &Index{
+					Type: &Type{
+						Table: &models.Table{
+							TableName: "TableA",
+						},
+					},
+				},
+				"TableA_Index2": &Index{
+					Type: &Type{
+						Table: &models.Table{
+							TableName: "TableA",
+						},
+					},
+				},
 			},
 			result: map[string]int{
 				"TableA": 2,
@@ -35,8 +49,20 @@ func Test_setIndexesToTables(t *testing.T) {
 				},
 			},
 			ix: map[string]*Index{
-				"TableA_Index1": &Index{},
-				"TableA_Index2": &Index{},
+				"TableA_Index1": &Index{
+					Type: &Type{
+						Table: &models.Table{
+							TableName: "TableA",
+						},
+					},
+				},
+				"TableA_Index2": &Index{
+					Type: &Type{
+						Table: &models.Table{
+							TableName: "TableA",
+						},
+					},
+				},
 			},
 			result: map[string]int{
 				"TableA": 2,
@@ -53,10 +79,34 @@ func Test_setIndexesToTables(t *testing.T) {
 				},
 			},
 			ix: map[string]*Index{
-				"TableA_Index1":               &Index{},
-				"TableA_Index2":               &Index{},
-				"TableB_Index1":               &Index{},
-				"TableB_Index2forTableA_Hoge": &Index{},
+				"TableA_Index1": &Index{
+					Type: &Type{
+						Table: &models.Table{
+							TableName: "TableA",
+						},
+					},
+				},
+				"TableA_Index2": &Index{
+					Type: &Type{
+						Table: &models.Table{
+							TableName: "TableA",
+						},
+					},
+				},
+				"TableB_Index1": &Index{
+					Type: &Type{
+						Table: &models.Table{
+							TableName: "TableB",
+						},
+					},
+				},
+				"TableB_Index2forTableA_Hoge": &Index{
+					Type: &Type{
+						Table: &models.Table{
+							TableName: "TableB",
+						},
+					},
+				},
 			},
 			result: map[string]int{
 				"TableA": 2,

--- a/loaders/parser.go
+++ b/loaders/parser.go
@@ -22,7 +22,6 @@ package loaders
 import (
 	"fmt"
 	"io/ioutil"
-	"strings"
 
 	"github.com/MakeNowJust/memefish/pkg/ast"
 	"github.com/MakeNowJust/memefish/pkg/parser"
@@ -37,21 +36,15 @@ func NewSpannerLoaderFromDDL(fpath string) (*SpannerLoaderFromDDL, error) {
 	}
 
 	tables := make(map[string]table)
-	stmts := strings.Split(string(b), ";")
-	for _, stmt := range stmts {
-		stmt := strings.TrimSpace(stmt)
-		if stmt == "" {
-			continue
-		}
-		ddl, err := (&parser.Parser{
-			Lexer: &parser.Lexer{
-				File: &token.File{FilePath: fpath, Buffer: stmt},
-			},
-		}).ParseDDL()
-		if err != nil {
-			return nil, err
-		}
-
+	ddls, err := (&parser.Parser{
+		Lexer: &parser.Lexer{
+			File: &token.File{FilePath: fpath, Buffer: string(b)},
+		},
+	}).ParseDDLs()
+	if err != nil {
+		return nil, err
+	}
+	for _, ddl := range ddls {
 		switch val := ddl.(type) {
 		case *ast.CreateTable:
 			v := tables[val.Name.Name]

--- a/test/testdata/schema.sql
+++ b/test/testdata/schema.sql
@@ -31,6 +31,7 @@ CREATE INDEX CompositePrimaryKeysByXY     ON CompositePrimaryKeys(X, Y);
 CREATE INDEX CompositePrimaryKeysByError  ON CompositePrimaryKeys(Error);
 CREATE INDEX CompositePrimaryKeysByError2 ON CompositePrimaryKeys(Error) STORING(Z);
 CREATE INDEX CompositePrimaryKeysByError3 ON CompositePrimaryKeys(Error) STORING(Z, Y);
+-- CREATE INDEX ForTestCommentIndex     ON CompositePrimaryKeys(X, Y, Z);
 
 CREATE TABLE OutOfOrderPrimaryKeys (
   PKey1 STRING(32) NOT NULL,


### PR DESCRIPTION
Hi.

I fixed this usecase.
```
cat test.sql
-- CREATE NULL_FILTERED INDEX test ON test(test);
CREATE TABLE test(
  test          STRING(36) NOT NULL,
) PRIMARY KEY(test);
```
```
go run main.go generate --from-ddl test.sql
error: syntax error:test.sql:1:49: expected token: CREATE, <ident>, but: <eof>

  1:  -- CREATE NULL_FILTERED INDEX test ON test(test)
                                                      ^

exit status 1
```

This error is caused  that `yo` parse multiple ddls in schema string by using `strings.Split(string(b), ";")` .
If schema string include comment with semicolon such as`-- .*;`  , 
parse will fail.

So I change to use `ParseDDLs` on `memefish`.
This can skip comment collectly.
And I fixed some failed test.

I agreed CLA.
https://cla.developers.google.com/
