### PR TITLE
[v2] Ignore alter table statement to add foreign key in schema file

### DIFF
--- a/v2/loader/loader_test.go
+++ b/v2/loader/loader_test.go
@@ -66,6 +66,15 @@ CREATE TABLE MaxLengths (
   MaxBytes BYTES(MAX) NOT NULL,
 ) PRIMARY KEY(MaxString);
 `
+
+	alterTableAddFKSchema = `
+ALTER TABLE Foo ADD FOREIGN KEY (CustomerID) REFERENCES Customers (CustomerID)
+
+`
+
+	alterTableAddConstraintFKSchema = `
+ALTER TABLE Foo ADD CONSTRAINT FK_CustomerOrder FOREIGN KEY (CustomerID) REFERENCES Customers (CustomerID)
+`
 )
 
 func TestLoader(t *testing.T) {
@@ -314,6 +323,22 @@ func TestLoader(t *testing.T) {
 						TableName: "MaxLengths",
 					},
 				},
+			},
+		},
+		{
+			name:   "AlterTableAddFK",
+			opt:    Option{},
+			schema: alterTableAddFKSchema,
+			expectedSchema: &models.Schema{
+				Types: []*models.Type{},
+			},
+		},
+		{
+			name:   "AlterTableAddConstraintFK",
+			opt:    Option{},
+			schema: alterTableAddConstraintFKSchema,
+			expectedSchema: &models.Schema{
+				Types: []*models.Type{},
 			},
 		},
 	}


### PR DESCRIPTION
Ignore alter table add foreign key statement when parsing schema file.

Spanner schema may contain alter table statements to add foreign keys.
For example, GetDatabaseDdl of spanner admin API seems to return such statement
when table A has a foreign key that references table B and B's name comes later in alphabetical order than A.
Such statements should not prevent yo from generating go code.
