### PR TITLE
Ignore indexes managed by spanner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           PROJECT: yo-test
           INSTANCE: yo-test
           DATABASE: yo-test
-      - image: gcr.io/cloud-spanner-emulator/emulator:1.0.0
+      - image: gcr.io/cloud-spanner-emulator/emulator:1.2.0
     working_directory: /go/src/github.com/cloudspannerecosystem/yo
     steps:
       - checkout

--- a/loaders/spanner.go
+++ b/loaders/spanner.go
@@ -296,7 +296,10 @@ func SpanTableIndexes(client *spanner.Client, table string) ([]*models.Index, er
 	const sqlstr = `SELECT ` +
 		`INDEX_NAME, IS_UNIQUE ` +
 		`FROM INFORMATION_SCHEMA.INDEXES ` +
-		`WHERE TABLE_SCHEMA = "" AND INDEX_NAME != "PRIMARY_KEY" AND TABLE_NAME = @table `
+		`WHERE TABLE_SCHEMA = "" ` +
+		`AND INDEX_NAME != "PRIMARY_KEY" ` +
+		`AND TABLE_NAME = @table ` +
+		`AND SPANNER_IS_MANAGED = FALSE `
 
 	stmt := spanner.NewStatement(sqlstr)
 	stmt.Params["table"] = table


### PR DESCRIPTION
Ignore indexes managed by spanner.

Spanner creates secondary backing indexes for foreign keys.
Such indexes have random names and are not suitable for use via yo generated code.
