### PR TITLE
Fix NewSpannerLoaderFromDDL to check if table exists

### DIFF
--- a/loaders/parser.go
+++ b/loaders/parser.go
@@ -51,7 +51,10 @@ func NewSpannerLoaderFromDDL(fpath string) (*SpannerLoaderFromDDL, error) {
 			v.createTable = val
 			tables[val.Name.Name] = v
 		case *ast.CreateIndex:
-			v := tables[val.TableName.Name]
+			v, ok := tables[val.TableName.Name]
+			if !ok {
+				return nil, fmt.Errorf("table '%s' is undefined, but got '%s'", val.TableName.Name, ddl.SQL())
+			}
 			v.createIndexes = append(v.createIndexes, val)
 			tables[val.TableName.Name] = v
 		default:


### PR DESCRIPTION
## What this PR does ?
Fixed not to panic when undefined table is specified in the "CreateIndex" statement.

**Example of panic**:
When `FooTable` is undefined,
```
CREATE INDEX FooTableByBarField ON FooTable(BarField);
```
causes the following panic.
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x16ec3bc]

goroutine 1 [running]:
go.mercari.io/yo/loaders.(*SpannerLoaderFromDDL).TableList(0xc00059e090, 0xc0005a20d8, 0x199, 0x101, 0xc000000180, 0xc000448000)
        /Users/bob/go/pkg/mod/go.mercari.io/yo@v0.3.8/loaders/parser.go:94 +0xdc
...
```

This often happens because of typos.