### PR TITLE
Fails if invalid custom types are specified

### DIFF
--- a/internal/loader.go
+++ b/internal/loader.go
@@ -210,9 +210,9 @@ func (tl *TypeLoader) LoadColumns(args *ArgType, typeTpl *Type) error {
 
 	// validate custom type columns
 	if columnTypes != nil {
-		columnSet := map[string]bool{}
+		columnSet := map[string]struct{}{}
 		for _, column := range columnList {
-			columnSet[column.ColumnName] = true
+			columnSet[column.ColumnName] = struct{}{}
 		}
 
 		for k, _ := range columnTypes {

--- a/internal/loader.go
+++ b/internal/loader.go
@@ -137,6 +137,16 @@ func (tl *TypeLoader) LoadTable(args *ArgType) (map[string]*Type, error) {
 		tableMap[ti.TableName] = typeTpl
 	}
 
+	// validate custom type tables
+	if tl.CustomTypes != nil {
+		for _, customTable := range tl.CustomTypes.Tables {
+			_, ok := tableMap[customTable.Name]
+			if !ok {
+				return nil, fmt.Errorf("unknown custom type table: %s", customTable.Name)
+			}
+		}
+	}
+
 	return tableMap, nil
 }
 
@@ -197,6 +207,21 @@ func (tl *TypeLoader) LoadColumns(args *ArgType, typeTpl *Type) error {
 	}
 
 	columnTypes := tl.tableCustomTypes(typeTpl.Table.TableName)
+
+	// validate custom type columns
+	if columnTypes != nil {
+		columnSet := map[string]bool{}
+		for _, column := range columnList {
+			columnSet[column.ColumnName] = true
+		}
+
+		for k, _ := range columnTypes {
+			if _, ok := columnSet[k]; !ok {
+				return fmt.Errorf("unknown custom type column %s in the table %s", k, typeTpl.Table.TableName)
+			}
+		}
+	}
+
 	// process columns
 	for _, c := range columnList {
 		ignore := false

--- a/test/testdata/custom_column_types.yml
+++ b/test/testdata/custom_column_types.yml
@@ -26,5 +26,5 @@ tables:
   - name: "FullTypes"
     columns:
       FTInt: "int32"
-      FTInitNull: "uint64"
+      FTIntNull: "uint64"
       FTFloat: "float32"

--- a/test/testdata/custom_column_types.yml
+++ b/test/testdata/custom_column_types.yml
@@ -26,5 +26,4 @@ tables:
   - name: "FullTypes"
     columns:
       FTInt: "int32"
-      FTIntNull: "uint64"
       FTFloat: "float32"

--- a/test/testmodels/customtypes/fulltype.yo.go
+++ b/test/testmodels/customtypes/fulltype.yo.go
@@ -26,7 +26,7 @@ type FullType struct {
 	FTTimestamp          time.Time           `spanner:"FTTimestamp" json:"FTTimestamp"`                   // FTTimestamp
 	FTTimestampNull      spanner.NullTime    `spanner:"FTTimestampNull" json:"FTTimestampNull"`           // FTTimestampNull
 	FTInt                int32               `spanner:"FTInt" json:"FTInt"`                               // FTInt
-	FTIntNull            spanner.NullInt64   `spanner:"FTIntNull" json:"FTIntNull"`                       // FTIntNull
+	FTIntNull            uint64              `spanner:"FTIntNull" json:"FTIntNull"`                       // FTIntNull
 	FTFloat              float32             `spanner:"FTFloat" json:"FTFloat"`                           // FTFloat
 	FTFloatNull          spanner.NullFloat64 `spanner:"FTFloatNull" json:"FTFloatNull"`                   // FTFloatNull
 	FTDate               civil.Date          `spanner:"FTDate" json:"FTDate"`                             // FTDate
@@ -220,7 +220,7 @@ func (ft *FullType) columnsToValues(cols []string) ([]interface{}, error) {
 		case "FTInt":
 			ret = append(ret, int64(ft.FTInt))
 		case "FTIntNull":
-			ret = append(ret, ft.FTIntNull)
+			ret = append(ret, spanner.NullInt64(ft.FTIntNull))
 		case "FTFloat":
 			ret = append(ret, float64(ft.FTFloat))
 		case "FTFloatNull":
@@ -269,10 +269,12 @@ func (ft *FullType) columnsToValues(cols []string) ([]interface{}, error) {
 // into FullType. The decoder is not goroutine-safe. Don't use it concurrently.
 func newFullType_Decoder(cols []string) func(*spanner.Row) (*FullType, error) {
 	var cFTInt int64
+	var cFTIntNull spanner.NullInt64
 	var cFTFloat float64
 	customPtrs := map[string]interface{}{
-		"FTInt":   &cFTInt,
-		"FTFloat": &cFTFloat,
+		"FTInt":     &cFTInt,
+		"FTIntNull": &cFTIntNull,
+		"FTFloat":   &cFTFloat,
 	}
 
 	return func(row *spanner.Row) (*FullType, error) {
@@ -286,6 +288,7 @@ func newFullType_Decoder(cols []string) func(*spanner.Row) (*FullType, error) {
 			return nil, err
 		}
 		ft.FTInt = int32(cFTInt)
+		ft.FTIntNull = uint64(cFTIntNull)
 		ft.FTFloat = float32(cFTFloat)
 
 		return &ft, nil

--- a/test/testmodels/customtypes/fulltype.yo.go
+++ b/test/testmodels/customtypes/fulltype.yo.go
@@ -26,7 +26,7 @@ type FullType struct {
 	FTTimestamp          time.Time           `spanner:"FTTimestamp" json:"FTTimestamp"`                   // FTTimestamp
 	FTTimestampNull      spanner.NullTime    `spanner:"FTTimestampNull" json:"FTTimestampNull"`           // FTTimestampNull
 	FTInt                int32               `spanner:"FTInt" json:"FTInt"`                               // FTInt
-	FTIntNull            uint64              `spanner:"FTIntNull" json:"FTIntNull"`                       // FTIntNull
+	FTIntNull            spanner.NullInt64   `spanner:"FTIntNull" json:"FTIntNull"`                       // FTIntNull
 	FTFloat              float32             `spanner:"FTFloat" json:"FTFloat"`                           // FTFloat
 	FTFloatNull          spanner.NullFloat64 `spanner:"FTFloatNull" json:"FTFloatNull"`                   // FTFloatNull
 	FTDate               civil.Date          `spanner:"FTDate" json:"FTDate"`                             // FTDate
@@ -220,7 +220,7 @@ func (ft *FullType) columnsToValues(cols []string) ([]interface{}, error) {
 		case "FTInt":
 			ret = append(ret, int64(ft.FTInt))
 		case "FTIntNull":
-			ret = append(ret, spanner.NullInt64(ft.FTIntNull))
+			ret = append(ret, ft.FTIntNull)
 		case "FTFloat":
 			ret = append(ret, float64(ft.FTFloat))
 		case "FTFloatNull":
@@ -269,12 +269,10 @@ func (ft *FullType) columnsToValues(cols []string) ([]interface{}, error) {
 // into FullType. The decoder is not goroutine-safe. Don't use it concurrently.
 func newFullType_Decoder(cols []string) func(*spanner.Row) (*FullType, error) {
 	var cFTInt int64
-	var cFTIntNull spanner.NullInt64
 	var cFTFloat float64
 	customPtrs := map[string]interface{}{
-		"FTInt":     &cFTInt,
-		"FTIntNull": &cFTIntNull,
-		"FTFloat":   &cFTFloat,
+		"FTInt":   &cFTInt,
+		"FTFloat": &cFTFloat,
 	}
 
 	return func(row *spanner.Row) (*FullType, error) {
@@ -288,7 +286,6 @@ func newFullType_Decoder(cols []string) func(*spanner.Row) (*FullType, error) {
 			return nil, err
 		}
 		ft.FTInt = int32(cFTInt)
-		ft.FTIntNull = uint64(cFTIntNull)
 		ft.FTFloat = float32(cFTFloat)
 
 		return &ft, nil

--- a/v2/loader/loader.go
+++ b/v2/loader/loader.go
@@ -236,9 +236,9 @@ func (tl *TypeLoader) LoadColumns(typeTpl *models.Type) error {
 
 	// validate custom type columns
 	if columnTypes != nil {
-		columnSet := map[string]bool{}
+		columnSet := map[string]struct{}{}
 		for _, column := range columnList {
-			columnSet[column.ColumnName] = true
+			columnSet[column.ColumnName] = struct{}{}
 		}
 
 		for k, _ := range columnTypes {


### PR DESCRIPTION
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/

Currently, the `yo` command succeeds even if non-existing custom type tables or columns are specified. This behavior makes it hard for users to notice misconfiguration in their custom types. It would be great if `yo` would validate their existence so I implemented the logic. Thank you for your review!
