### PR TITLE
circleci: upgrade cloud-spanner-emulator/emulator to 1.4.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           PROJECT: yo-test
           INSTANCE: yo-test
           DATABASE: yo-test
-      - image: gcr.io/cloud-spanner-emulator/emulator:1.4.0
+      - image: gcr.io/cloud-spanner-emulator/emulator:1.4.2
     working_directory: /go/src/github.com/cloudspannerecosystem/yo
     steps:
       - checkout
@@ -62,7 +62,7 @@ jobs:
           PROJECT: yo-test
           INSTANCE: yo-test
           DATABASE: yo-test
-      - image: gcr.io/cloud-spanner-emulator/emulator:1.4.0
+      - image: gcr.io/cloud-spanner-emulator/emulator:1.4.2
     working_directory: /go/src/github.com/cloudspannerecosystem/yo
     steps:
       - checkout


### PR DESCRIPTION
circleci: upgrade cloud-spanner-emulator/emulator to 1.4.2.