### PR TITLE
Use build info to retrieve version information

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	pathpkg "path"
+	"runtime/debug"
 	"strings"
 
 	"cloud.google.com/go/spanner"
@@ -43,8 +44,6 @@ const (
   yo $SPANNER_PROJECT_NAME $SPANNER_INSTANCE_NAME $SPANNER_DATABASE_NAME -o models --custom-types-file custom_column_types.yml
 `
 )
-
-var version = "dev"
 
 var (
 	rootOpts = internal.ArgType{}
@@ -105,7 +104,7 @@ var (
 		},
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		Version:       version,
+		Version:       version(),
 	}
 )
 
@@ -229,4 +228,13 @@ func connectSpanner(args *internal.ArgType) (*spanner.Client, error) {
 	}
 
 	return spannerClient, nil
+}
+
+func version() string {
+	// Not using ldflags to show proper version even when a user "go install"s yo
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "(devel)"
+	}
+	return info.Main.Version
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,8 @@ const (
 `
 )
 
+var version string
+
 var (
 	rootOpts = internal.ArgType{}
 	rootCmd  = &cobra.Command{
@@ -104,7 +106,7 @@ var (
 		},
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		Version:       version(),
+		Version:       versionInfo(),
 	}
 )
 
@@ -230,8 +232,12 @@ func connectSpanner(args *internal.ArgType) (*spanner.Client, error) {
 	return spannerClient, nil
 }
 
-func version() string {
-	// Not using ldflags to show proper version even when a user "go install"s yo
+func versionInfo() string {
+	if version != "" {
+		return version
+	}
+
+	// For those who "go install" yo
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
 		return "(devel)"

--- a/v2/cmd/root.go
+++ b/v2/cmd/root.go
@@ -20,6 +20,7 @@
 package cmd
 
 import (
+	"runtime/debug"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -36,7 +37,7 @@ const (
 `
 )
 
-var version = "dev"
+var version string
 
 var (
 	rootCmd = &cobra.Command{
@@ -49,10 +50,23 @@ var (
 		RunE:          nil,
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		Version:       version,
+		Version:       versionInfo(),
 	}
 )
 
 func Execute() error {
 	return rootCmd.Execute()
+}
+
+func versionInfo() string {
+	if version != "" {
+		return version
+	}
+
+	// For those who "go install" yo
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "(devel)"
+	}
+	return info.Main.Version
 }


### PR DESCRIPTION
Follow up on https://github.com/cloudspannerecosystem/yo/pull/105 🙇 
Not using ldflags to show proper version even when a user 'go install's yo.
