### PR TITLE
Fix typo in index.go.tpl

### DIFF
--- a/v2/module/builtin/templates/index.go.tpl
+++ b/v2/module/builtin/templates/index.go.tpl
@@ -103,7 +103,7 @@ func Find{{ .FuncName }}(ctx context.Context, db YODB{{ goParams .Fields true tr
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index '{{ .IndexName }}'.
+// Generated from index '{{ .IndexName }}'.
 func Read{{ .FuncName }}(ctx context.Context, db YODB, keys spanner.KeySet) ([]*{{ .Type.Name }}, error) {
 	var res []*{{ .Type.Name }}
     columns := []string{

--- a/v2/test/testmodels/default/composite_primary_key.yo.go
+++ b/v2/test/testmodels/default/composite_primary_key.yo.go
@@ -259,7 +259,7 @@ func FindCompositePrimaryKeysByCompositePrimaryKeysByError(ctx context.Context, 
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'CompositePrimaryKeysByError'.
+// Generated from index 'CompositePrimaryKeysByError'.
 func ReadCompositePrimaryKeysByCompositePrimaryKeysByError(ctx context.Context, db YODB, keys spanner.KeySet) ([]*CompositePrimaryKey, error) {
 	var res []*CompositePrimaryKey
 	columns := []string{
@@ -334,7 +334,7 @@ func FindCompositePrimaryKeysByCompositePrimaryKeysByError2(ctx context.Context,
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'CompositePrimaryKeysByError2'.
+// Generated from index 'CompositePrimaryKeysByError2'.
 func ReadCompositePrimaryKeysByCompositePrimaryKeysByError2(ctx context.Context, db YODB, keys spanner.KeySet) ([]*CompositePrimaryKey, error) {
 	var res []*CompositePrimaryKey
 	columns := []string{
@@ -410,7 +410,7 @@ func FindCompositePrimaryKeysByCompositePrimaryKeysByError3(ctx context.Context,
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'CompositePrimaryKeysByError3'.
+// Generated from index 'CompositePrimaryKeysByError3'.
 func ReadCompositePrimaryKeysByCompositePrimaryKeysByError3(ctx context.Context, db YODB, keys spanner.KeySet) ([]*CompositePrimaryKey, error) {
 	var res []*CompositePrimaryKey
 	columns := []string{
@@ -488,7 +488,7 @@ func FindCompositePrimaryKeysByCompositePrimaryKeysByXY(ctx context.Context, db 
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'CompositePrimaryKeysByXY'.
+// Generated from index 'CompositePrimaryKeysByXY'.
 func ReadCompositePrimaryKeysByCompositePrimaryKeysByXY(ctx context.Context, db YODB, keys spanner.KeySet) ([]*CompositePrimaryKey, error) {
 	var res []*CompositePrimaryKey
 	columns := []string{

--- a/v2/test/testmodels/default/custom_composite_primary_key.yo.go
+++ b/v2/test/testmodels/default/custom_composite_primary_key.yo.go
@@ -259,7 +259,7 @@ func FindCustomCompositePrimaryKeysByCustomCompositePrimaryKeysByError(ctx conte
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'CustomCompositePrimaryKeysByError'.
+// Generated from index 'CustomCompositePrimaryKeysByError'.
 func ReadCustomCompositePrimaryKeysByCustomCompositePrimaryKeysByError(ctx context.Context, db YODB, keys spanner.KeySet) ([]*CustomCompositePrimaryKey, error) {
 	var res []*CustomCompositePrimaryKey
 	columns := []string{
@@ -334,7 +334,7 @@ func FindCustomCompositePrimaryKeysByCustomCompositePrimaryKeysByError2(ctx cont
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'CustomCompositePrimaryKeysByError2'.
+// Generated from index 'CustomCompositePrimaryKeysByError2'.
 func ReadCustomCompositePrimaryKeysByCustomCompositePrimaryKeysByError2(ctx context.Context, db YODB, keys spanner.KeySet) ([]*CustomCompositePrimaryKey, error) {
 	var res []*CustomCompositePrimaryKey
 	columns := []string{
@@ -410,7 +410,7 @@ func FindCustomCompositePrimaryKeysByCustomCompositePrimaryKeysByError3(ctx cont
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'CustomCompositePrimaryKeysByError3'.
+// Generated from index 'CustomCompositePrimaryKeysByError3'.
 func ReadCustomCompositePrimaryKeysByCustomCompositePrimaryKeysByError3(ctx context.Context, db YODB, keys spanner.KeySet) ([]*CustomCompositePrimaryKey, error) {
 	var res []*CustomCompositePrimaryKey
 	columns := []string{
@@ -488,7 +488,7 @@ func FindCustomCompositePrimaryKeysByCustomCompositePrimaryKeysByXY(ctx context.
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'CustomCompositePrimaryKeysByXY'.
+// Generated from index 'CustomCompositePrimaryKeysByXY'.
 func ReadCustomCompositePrimaryKeysByCustomCompositePrimaryKeysByXY(ctx context.Context, db YODB, keys spanner.KeySet) ([]*CustomCompositePrimaryKey, error) {
 	var res []*CustomCompositePrimaryKey
 	columns := []string{

--- a/v2/test/testmodels/default/full_type.yo.go
+++ b/v2/test/testmodels/default/full_type.yo.go
@@ -440,7 +440,7 @@ func FindFullTypeByFullTypesByFTString(ctx context.Context, db YODB, fTString st
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'FullTypesByFTString'.
+// Generated from index 'FullTypesByFTString'.
 func ReadFullTypeByFullTypesByFTString(ctx context.Context, db YODB, keys spanner.KeySet) ([]*FullType, error) {
 	var res []*FullType
 	columns := []string{
@@ -523,7 +523,7 @@ func FindFullTypesByFullTypesByInTimestampNull(ctx context.Context, db YODB, fTI
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'FullTypesByInTimestampNull'.
+// Generated from index 'FullTypesByInTimestampNull'.
 func ReadFullTypesByFullTypesByInTimestampNull(ctx context.Context, db YODB, keys spanner.KeySet) ([]*FullType, error) {
 	var res []*FullType
 	columns := []string{
@@ -599,7 +599,7 @@ func FindFullTypesByFullTypesByIntDate(ctx context.Context, db YODB, fTInt int64
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'FullTypesByIntDate'.
+// Generated from index 'FullTypesByIntDate'.
 func ReadFullTypesByFullTypesByIntDate(ctx context.Context, db YODB, keys spanner.KeySet) ([]*FullType, error) {
 	var res []*FullType
 	columns := []string{
@@ -675,7 +675,7 @@ func FindFullTypesByFullTypesByIntTimestamp(ctx context.Context, db YODB, fTInt 
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'FullTypesByIntTimestamp'.
+// Generated from index 'FullTypesByIntTimestamp'.
 func ReadFullTypesByFullTypesByIntTimestamp(ctx context.Context, db YODB, keys spanner.KeySet) ([]*FullType, error) {
 	var res []*FullType
 	columns := []string{
@@ -750,7 +750,7 @@ func FindFullTypesByFullTypesByTimestamp(ctx context.Context, db YODB, fTTimesta
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'FullTypesByTimestamp'.
+// Generated from index 'FullTypesByTimestamp'.
 func ReadFullTypesByFullTypesByTimestamp(ctx context.Context, db YODB, keys spanner.KeySet) ([]*FullType, error) {
 	var res []*FullType
 	columns := []string{

--- a/v2/test/testmodels/default/snake_case.yo.go
+++ b/v2/test/testmodels/default/snake_case.yo.go
@@ -231,7 +231,7 @@ func FindSnakeCasesBySnakeCasesByStringID(ctx context.Context, db YODB, stringID
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'snake_cases_by_string_id'.
+// Generated from index 'snake_cases_by_string_id'.
 func ReadSnakeCasesBySnakeCasesByStringID(ctx context.Context, db YODB, keys spanner.KeySet) ([]*SnakeCase, error) {
 	var res []*SnakeCase
 	columns := []string{


### PR DESCRIPTION
ReadXXX is generated from both unique and non-unique indexes, so it would be better if we remove the "unique" word 🙂 
