### PR TITLE
Remove key column conflict if spanner has a column named `key`

### DIFF
--- a/v2/module/builtin/templates/operation.go.tpl
+++ b/v2/module/builtin/templates/operation.go.tpl
@@ -47,8 +47,8 @@ func ({{ $short }} *{{ .Name }}) UpdateColumns(ctx context.Context, cols ...stri
 
 // Find{{ .Name }} gets a {{ .Name }} by primary key
 func Find{{ .Name }}(ctx context.Context, db YODB{{ goParams .PrimaryKeyFields true true }}) (*{{ .Name }}, error) {
-	key := spanner.Key{ {{ goEncodedParams .PrimaryKeyFields false }} }
-	row, err := db.ReadRow(ctx, "{{ $table }}", key, {{ .Name }}Columns())
+	key_ := spanner.Key{ {{ goEncodedParams .PrimaryKeyFields false }} }
+	row, err := db.ReadRow(ctx, "{{ $table }}", key_, {{ .Name }}Columns())
 	if err != nil {
 		return nil, newError("Find{{ .Name }}", "{{ $table }}", err)
 	}

--- a/v2/test/testmodels/default/composite_primary_key.yo.go
+++ b/v2/test/testmodels/default/composite_primary_key.yo.go
@@ -168,8 +168,8 @@ func (cpk *CompositePrimaryKey) UpdateColumns(ctx context.Context, cols ...strin
 
 // FindCompositePrimaryKey gets a CompositePrimaryKey by primary key
 func FindCompositePrimaryKey(ctx context.Context, db YODB, pKey1 string, pKey2 int64) (*CompositePrimaryKey, error) {
-	key := spanner.Key{yoEncode(pKey1), yoEncode(pKey2)}
-	row, err := db.ReadRow(ctx, "CompositePrimaryKeys", key, CompositePrimaryKeyColumns())
+	key_ := spanner.Key{yoEncode(pKey1), yoEncode(pKey2)}
+	row, err := db.ReadRow(ctx, "CompositePrimaryKeys", key_, CompositePrimaryKeyColumns())
 	if err != nil {
 		return nil, newError("FindCompositePrimaryKey", "CompositePrimaryKeys", err)
 	}

--- a/v2/test/testmodels/default/custom_composite_primary_key.yo.go
+++ b/v2/test/testmodels/default/custom_composite_primary_key.yo.go
@@ -168,8 +168,8 @@ func (ccpk *CustomCompositePrimaryKey) UpdateColumns(ctx context.Context, cols .
 
 // FindCustomCompositePrimaryKey gets a CustomCompositePrimaryKey by primary key
 func FindCustomCompositePrimaryKey(ctx context.Context, db YODB, pKey1 string, pKey2 uint32) (*CustomCompositePrimaryKey, error) {
-	key := spanner.Key{yoEncode(pKey1), yoEncode(pKey2)}
-	row, err := db.ReadRow(ctx, "CustomCompositePrimaryKeys", key, CustomCompositePrimaryKeyColumns())
+	key_ := spanner.Key{yoEncode(pKey1), yoEncode(pKey2)}
+	row, err := db.ReadRow(ctx, "CustomCompositePrimaryKeys", key_, CustomCompositePrimaryKeyColumns())
 	if err != nil {
 		return nil, newError("FindCustomCompositePrimaryKey", "CustomCompositePrimaryKeys", err)
 	}

--- a/v2/test/testmodels/default/custom_primitive_type.yo.go
+++ b/v2/test/testmodels/default/custom_primitive_type.yo.go
@@ -348,8 +348,8 @@ func (cpt *CustomPrimitiveType) UpdateColumns(ctx context.Context, cols ...strin
 
 // FindCustomPrimitiveType gets a CustomPrimitiveType by primary key
 func FindCustomPrimitiveType(ctx context.Context, db YODB, pKey string) (*CustomPrimitiveType, error) {
-	key := spanner.Key{yoEncode(pKey)}
-	row, err := db.ReadRow(ctx, "CustomPrimitiveTypes", key, CustomPrimitiveTypeColumns())
+	key_ := spanner.Key{yoEncode(pKey)}
+	row, err := db.ReadRow(ctx, "CustomPrimitiveTypes", key_, CustomPrimitiveTypeColumns())
 	if err != nil {
 		return nil, newError("FindCustomPrimitiveType", "CustomPrimitiveTypes", err)
 	}

--- a/v2/test/testmodels/default/fereign_item.yo.go
+++ b/v2/test/testmodels/default/fereign_item.yo.go
@@ -138,8 +138,8 @@ func (fi *FereignItem) UpdateColumns(ctx context.Context, cols ...string) (*span
 
 // FindFereignItem gets a FereignItem by primary key
 func FindFereignItem(ctx context.Context, db YODB, id int64) (*FereignItem, error) {
-	key := spanner.Key{yoEncode(id)}
-	row, err := db.ReadRow(ctx, "FereignItems", key, FereignItemColumns())
+	key_ := spanner.Key{yoEncode(id)}
+	row, err := db.ReadRow(ctx, "FereignItems", key_, FereignItemColumns())
 	if err != nil {
 		return nil, newError("FindFereignItem", "FereignItems", err)
 	}

--- a/v2/test/testmodels/default/full_type.yo.go
+++ b/v2/test/testmodels/default/full_type.yo.go
@@ -352,8 +352,8 @@ func (ft *FullType) UpdateColumns(ctx context.Context, cols ...string) (*spanner
 
 // FindFullType gets a FullType by primary key
 func FindFullType(ctx context.Context, db YODB, pKey string) (*FullType, error) {
-	key := spanner.Key{yoEncode(pKey)}
-	row, err := db.ReadRow(ctx, "FullTypes", key, FullTypeColumns())
+	key_ := spanner.Key{yoEncode(pKey)}
+	row, err := db.ReadRow(ctx, "FullTypes", key_, FullTypeColumns())
 	if err != nil {
 		return nil, newError("FindFullType", "FullTypes", err)
 	}

--- a/v2/test/testmodels/default/generated_column.yo.go
+++ b/v2/test/testmodels/default/generated_column.yo.go
@@ -144,8 +144,8 @@ func (gc *GeneratedColumn) UpdateColumns(ctx context.Context, cols ...string) (*
 
 // FindGeneratedColumn gets a GeneratedColumn by primary key
 func FindGeneratedColumn(ctx context.Context, db YODB, id int64) (*GeneratedColumn, error) {
-	key := spanner.Key{yoEncode(id)}
-	row, err := db.ReadRow(ctx, "GeneratedColumns", key, GeneratedColumnColumns())
+	key_ := spanner.Key{yoEncode(id)}
+	row, err := db.ReadRow(ctx, "GeneratedColumns", key_, GeneratedColumnColumns())
 	if err != nil {
 		return nil, newError("FindGeneratedColumn", "GeneratedColumns", err)
 	}

--- a/v2/test/testmodels/default/inflection.yo.go
+++ b/v2/test/testmodels/default/inflection.yo.go
@@ -131,8 +131,8 @@ func (i *Inflection) UpdateColumns(ctx context.Context, cols ...string) (*spanne
 
 // FindInflection gets a Inflection by primary key
 func FindInflection(ctx context.Context, db YODB, x string) (*Inflection, error) {
-	key := spanner.Key{yoEncode(x)}
-	row, err := db.ReadRow(ctx, "Inflectionzz", key, InflectionColumns())
+	key_ := spanner.Key{yoEncode(x)}
+	row, err := db.ReadRow(ctx, "Inflectionzz", key_, InflectionColumns())
 	if err != nil {
 		return nil, newError("FindInflection", "Inflectionzz", err)
 	}

--- a/v2/test/testmodels/default/item.yo.go
+++ b/v2/test/testmodels/default/item.yo.go
@@ -131,8 +131,8 @@ func (i *Item) UpdateColumns(ctx context.Context, cols ...string) (*spanner.Muta
 
 // FindItem gets a Item by primary key
 func FindItem(ctx context.Context, db YODB, id int64) (*Item, error) {
-	key := spanner.Key{yoEncode(id)}
-	row, err := db.ReadRow(ctx, "Items", key, ItemColumns())
+	key_ := spanner.Key{yoEncode(id)}
+	row, err := db.ReadRow(ctx, "Items", key_, ItemColumns())
 	if err != nil {
 		return nil, newError("FindItem", "Items", err)
 	}

--- a/v2/test/testmodels/default/max_length.yo.go
+++ b/v2/test/testmodels/default/max_length.yo.go
@@ -131,8 +131,8 @@ func (ml *MaxLength) UpdateColumns(ctx context.Context, cols ...string) (*spanne
 
 // FindMaxLength gets a MaxLength by primary key
 func FindMaxLength(ctx context.Context, db YODB, maxString string) (*MaxLength, error) {
-	key := spanner.Key{yoEncode(maxString)}
-	row, err := db.ReadRow(ctx, "MaxLengths", key, MaxLengthColumns())
+	key_ := spanner.Key{yoEncode(maxString)}
+	row, err := db.ReadRow(ctx, "MaxLengths", key_, MaxLengthColumns())
 	if err != nil {
 		return nil, newError("FindMaxLength", "MaxLengths", err)
 	}

--- a/v2/test/testmodels/default/snake_case.yo.go
+++ b/v2/test/testmodels/default/snake_case.yo.go
@@ -139,8 +139,8 @@ func (sc *SnakeCase) UpdateColumns(ctx context.Context, cols ...string) (*spanne
 
 // FindSnakeCase gets a SnakeCase by primary key
 func FindSnakeCase(ctx context.Context, db YODB, id int64) (*SnakeCase, error) {
-	key := spanner.Key{yoEncode(id)}
-	row, err := db.ReadRow(ctx, "snake_cases", key, SnakeCaseColumns())
+	key_ := spanner.Key{yoEncode(id)}
+	row, err := db.ReadRow(ctx, "snake_cases", key_, SnakeCaseColumns())
 	if err != nil {
 		return nil, newError("FindSnakeCase", "snake_cases", err)
 	}

--- a/v2/test/testmodels/legacy_default/composite_primary_key.yo.go
+++ b/v2/test/testmodels/legacy_default/composite_primary_key.yo.go
@@ -168,8 +168,8 @@ func (cpk *CompositePrimaryKey) UpdateColumns(ctx context.Context, cols ...strin
 
 // FindCompositePrimaryKey gets a CompositePrimaryKey by primary key
 func FindCompositePrimaryKey(ctx context.Context, db YODB, pKey1 string, pKey2 int64) (*CompositePrimaryKey, error) {
-	key := spanner.Key{yoEncode(pKey1), yoEncode(pKey2)}
-	row, err := db.ReadRow(ctx, "CompositePrimaryKeys", key, CompositePrimaryKeyColumns())
+	key_ := spanner.Key{yoEncode(pKey1), yoEncode(pKey2)}
+	row, err := db.ReadRow(ctx, "CompositePrimaryKeys", key_, CompositePrimaryKeyColumns())
 	if err != nil {
 		return nil, newError("FindCompositePrimaryKey", "CompositePrimaryKeys", err)
 	}

--- a/v2/test/testmodels/legacy_default/custom_composite_primary_key.yo.go
+++ b/v2/test/testmodels/legacy_default/custom_composite_primary_key.yo.go
@@ -168,8 +168,8 @@ func (ccpk *CustomCompositePrimaryKey) UpdateColumns(ctx context.Context, cols .
 
 // FindCustomCompositePrimaryKey gets a CustomCompositePrimaryKey by primary key
 func FindCustomCompositePrimaryKey(ctx context.Context, db YODB, pKey1 string, pKey2 uint32) (*CustomCompositePrimaryKey, error) {
-	key := spanner.Key{yoEncode(pKey1), yoEncode(pKey2)}
-	row, err := db.ReadRow(ctx, "CustomCompositePrimaryKeys", key, CustomCompositePrimaryKeyColumns())
+	key_ := spanner.Key{yoEncode(pKey1), yoEncode(pKey2)}
+	row, err := db.ReadRow(ctx, "CustomCompositePrimaryKeys", key_, CustomCompositePrimaryKeyColumns())
 	if err != nil {
 		return nil, newError("FindCustomCompositePrimaryKey", "CustomCompositePrimaryKeys", err)
 	}

--- a/v2/test/testmodels/legacy_default/custom_primitive_type.yo.go
+++ b/v2/test/testmodels/legacy_default/custom_primitive_type.yo.go
@@ -348,8 +348,8 @@ func (cpt *CustomPrimitiveType) UpdateColumns(ctx context.Context, cols ...strin
 
 // FindCustomPrimitiveType gets a CustomPrimitiveType by primary key
 func FindCustomPrimitiveType(ctx context.Context, db YODB, pKey string) (*CustomPrimitiveType, error) {
-	key := spanner.Key{yoEncode(pKey)}
-	row, err := db.ReadRow(ctx, "CustomPrimitiveTypes", key, CustomPrimitiveTypeColumns())
+	key_ := spanner.Key{yoEncode(pKey)}
+	row, err := db.ReadRow(ctx, "CustomPrimitiveTypes", key_, CustomPrimitiveTypeColumns())
 	if err != nil {
 		return nil, newError("FindCustomPrimitiveType", "CustomPrimitiveTypes", err)
 	}

--- a/v2/test/testmodels/legacy_default/fereign_item.yo.go
+++ b/v2/test/testmodels/legacy_default/fereign_item.yo.go
@@ -138,8 +138,8 @@ func (fi *FereignItem) UpdateColumns(ctx context.Context, cols ...string) (*span
 
 // FindFereignItem gets a FereignItem by primary key
 func FindFereignItem(ctx context.Context, db YODB, id int64) (*FereignItem, error) {
-	key := spanner.Key{yoEncode(id)}
-	row, err := db.ReadRow(ctx, "FereignItems", key, FereignItemColumns())
+	key_ := spanner.Key{yoEncode(id)}
+	row, err := db.ReadRow(ctx, "FereignItems", key_, FereignItemColumns())
 	if err != nil {
 		return nil, newError("FindFereignItem", "FereignItems", err)
 	}

--- a/v2/test/testmodels/legacy_default/full_type.yo.go
+++ b/v2/test/testmodels/legacy_default/full_type.yo.go
@@ -352,8 +352,8 @@ func (ft *FullType) UpdateColumns(ctx context.Context, cols ...string) (*spanner
 
 // FindFullType gets a FullType by primary key
 func FindFullType(ctx context.Context, db YODB, pKey string) (*FullType, error) {
-	key := spanner.Key{yoEncode(pKey)}
-	row, err := db.ReadRow(ctx, "FullTypes", key, FullTypeColumns())
+	key_ := spanner.Key{yoEncode(pKey)}
+	row, err := db.ReadRow(ctx, "FullTypes", key_, FullTypeColumns())
 	if err != nil {
 		return nil, newError("FindFullType", "FullTypes", err)
 	}

--- a/v2/test/testmodels/legacy_default/generated_column.yo.go
+++ b/v2/test/testmodels/legacy_default/generated_column.yo.go
@@ -144,8 +144,8 @@ func (gc *GeneratedColumn) UpdateColumns(ctx context.Context, cols ...string) (*
 
 // FindGeneratedColumn gets a GeneratedColumn by primary key
 func FindGeneratedColumn(ctx context.Context, db YODB, id int64) (*GeneratedColumn, error) {
-	key := spanner.Key{yoEncode(id)}
-	row, err := db.ReadRow(ctx, "GeneratedColumns", key, GeneratedColumnColumns())
+	key_ := spanner.Key{yoEncode(id)}
+	row, err := db.ReadRow(ctx, "GeneratedColumns", key_, GeneratedColumnColumns())
 	if err != nil {
 		return nil, newError("FindGeneratedColumn", "GeneratedColumns", err)
 	}

--- a/v2/test/testmodels/legacy_default/inflection.yo.go
+++ b/v2/test/testmodels/legacy_default/inflection.yo.go
@@ -131,8 +131,8 @@ func (i *Inflection) UpdateColumns(ctx context.Context, cols ...string) (*spanne
 
 // FindInflection gets a Inflection by primary key
 func FindInflection(ctx context.Context, db YODB, x string) (*Inflection, error) {
-	key := spanner.Key{yoEncode(x)}
-	row, err := db.ReadRow(ctx, "Inflectionzz", key, InflectionColumns())
+	key_ := spanner.Key{yoEncode(x)}
+	row, err := db.ReadRow(ctx, "Inflectionzz", key_, InflectionColumns())
 	if err != nil {
 		return nil, newError("FindInflection", "Inflectionzz", err)
 	}

--- a/v2/test/testmodels/legacy_default/item.yo.go
+++ b/v2/test/testmodels/legacy_default/item.yo.go
@@ -131,8 +131,8 @@ func (i *Item) UpdateColumns(ctx context.Context, cols ...string) (*spanner.Muta
 
 // FindItem gets a Item by primary key
 func FindItem(ctx context.Context, db YODB, id int64) (*Item, error) {
-	key := spanner.Key{yoEncode(id)}
-	row, err := db.ReadRow(ctx, "Items", key, ItemColumns())
+	key_ := spanner.Key{yoEncode(id)}
+	row, err := db.ReadRow(ctx, "Items", key_, ItemColumns())
 	if err != nil {
 		return nil, newError("FindItem", "Items", err)
 	}

--- a/v2/test/testmodels/legacy_default/max_length.yo.go
+++ b/v2/test/testmodels/legacy_default/max_length.yo.go
@@ -131,8 +131,8 @@ func (ml *MaxLength) UpdateColumns(ctx context.Context, cols ...string) (*spanne
 
 // FindMaxLength gets a MaxLength by primary key
 func FindMaxLength(ctx context.Context, db YODB, maxString string) (*MaxLength, error) {
-	key := spanner.Key{yoEncode(maxString)}
-	row, err := db.ReadRow(ctx, "MaxLengths", key, MaxLengthColumns())
+	key_ := spanner.Key{yoEncode(maxString)}
+	row, err := db.ReadRow(ctx, "MaxLengths", key_, MaxLengthColumns())
 	if err != nil {
 		return nil, newError("FindMaxLength", "MaxLengths", err)
 	}

--- a/v2/test/testmodels/legacy_default/snake_case.yo.go
+++ b/v2/test/testmodels/legacy_default/snake_case.yo.go
@@ -139,8 +139,8 @@ func (sc *SnakeCase) UpdateColumns(ctx context.Context, cols ...string) (*spanne
 
 // FindSnakeCase gets a SnakeCase by primary key
 func FindSnakeCase(ctx context.Context, db YODB, id int64) (*SnakeCase, error) {
-	key := spanner.Key{yoEncode(id)}
-	row, err := db.ReadRow(ctx, "snake_cases", key, SnakeCaseColumns())
+	key_ := spanner.Key{yoEncode(id)}
+	row, err := db.ReadRow(ctx, "snake_cases", key_, SnakeCaseColumns())
 	if err != nil {
 		return nil, newError("FindSnakeCase", "snake_cases", err)
 	}


### PR DESCRIPTION
Our database has a primary key called `key` so when we use yo to generate, we have a name conflict in templates
```
func FindSearchConditionsMailLog(ctx context.Context, db YORODB, key string) (*SearchConditionsMailLog, error) {
	key := spanner.Key{key}
```
and the following error
```
cannot use spanner.Key{…} (value of type "cloud.google.com/go/spanner".Key) as int64 value in assignment
```
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
