### PR TITLE
[v2]change unsupported DDL behavior

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           PROJECT: yo-test
           INSTANCE: yo-test
           DATABASE: yo-test
-      - image: gcr.io/cloud-spanner-emulator/emulator:1.5.14
+      - image: gcr.io/cloud-spanner-emulator/emulator:1.5.9
     working_directory: /go/src/github.com/cloudspannerecosystem/yo
     steps:
       - checkout
@@ -62,7 +62,7 @@ jobs:
           PROJECT: yo-test
           INSTANCE: yo-test
           DATABASE: yo-test
-      - image: gcr.io/cloud-spanner-emulator/emulator:1.5.14
+      - image: gcr.io/cloud-spanner-emulator/emulator:1.5.9
     working_directory: /go/src/github.com/cloudspannerecosystem/yo
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           PROJECT: yo-test
           INSTANCE: yo-test
           DATABASE: yo-test
-      - image: gcr.io/cloud-spanner-emulator/emulator:1.5.9
+      - image: gcr.io/cloud-spanner-emulator/emulator:1.5.14
     working_directory: /go/src/github.com/cloudspannerecosystem/yo
     steps:
       - checkout
@@ -62,7 +62,7 @@ jobs:
           PROJECT: yo-test
           INSTANCE: yo-test
           DATABASE: yo-test
-      - image: gcr.io/cloud-spanner-emulator/emulator:1.5.9
+      - image: gcr.io/cloud-spanner-emulator/emulator:1.5.14
     working_directory: /go/src/github.com/cloudspannerecosystem/yo
     steps:
       - checkout

--- a/v2/loader/schema_parser_source.go
+++ b/v2/loader/schema_parser_source.go
@@ -58,15 +58,10 @@ func NewSchemaParserSource(fpath string) (SchemaSource, error) {
 			v := tables[tableName]
 			v.createIndexes = append(v.createIndexes, val)
 			tables[tableName] = v
-		case *spansql.CreateChangeStream:
-			// CreateChangeStream isn't supported yet
-			continue
 		case *spansql.AlterTable:
 			if isAlterTableAddFK(val) {
 				continue
 			}
-			return nil, fmt.Errorf("unknown statement is specified: %s", ddlstmt.SQL())
-		default:
 			return nil, fmt.Errorf("unknown statement is specified: %s", ddlstmt.SQL())
 		}
 	}

--- a/v2/loader/schema_parser_source.go
+++ b/v2/loader/schema_parser_source.go
@@ -21,6 +21,7 @@ package loader
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"sort"
 	"strings"
@@ -58,13 +59,16 @@ func NewSchemaParserSource(fpath string) (SchemaSource, error) {
 			v := tables[tableName]
 			v.createIndexes = append(v.createIndexes, val)
 			tables[tableName] = v
+		case *spansql.CreateChangeStream:
+			log.Printf("skipped. CreateChangeStream isn't supported yet. got ' %s'", ddlstmt.SQL())
+			continue
 		case *spansql.AlterTable:
 			if isAlterTableAddFK(val) {
 				continue
 			}
-			return nil, fmt.Errorf("stmt should be CreateTable, CreateIndex or AlterTableAddForeignKey, but got '%s'", ddlstmt.SQL())
+			return nil, fmt.Errorf("stmt should be CreateTable, CreateIndex, CreateChangeStream or AlterTableAddForeignKey, but got '%s'", ddlstmt.SQL())
 		default:
-			return nil, fmt.Errorf("stmt should be CreateTable, CreateIndex or AlterTableAddForeignKey, but got '%s'", ddlstmt.SQL())
+			return nil, fmt.Errorf("stmt should be CreateTable, CreateIndex, CreateChangeStream or AlterTableAddForeignKey, but got '%s'", ddlstmt.SQL())
 		}
 	}
 

--- a/v2/loader/schema_parser_source.go
+++ b/v2/loader/schema_parser_source.go
@@ -21,7 +21,6 @@ package loader
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"sort"
 	"strings"
@@ -60,7 +59,7 @@ func NewSchemaParserSource(fpath string) (SchemaSource, error) {
 			v.createIndexes = append(v.createIndexes, val)
 			tables[tableName] = v
 		case *spansql.CreateChangeStream:
-			log.Printf("skipped. CreateChangeStream isn't supported yet. got ' %s'", ddlstmt.SQL())
+			// CreateChangeStream isn't supported yet
 			continue
 		case *spansql.AlterTable:
 			if isAlterTableAddFK(val) {

--- a/v2/loader/schema_parser_source.go
+++ b/v2/loader/schema_parser_source.go
@@ -65,9 +65,9 @@ func NewSchemaParserSource(fpath string) (SchemaSource, error) {
 			if isAlterTableAddFK(val) {
 				continue
 			}
-			return nil, fmt.Errorf("stmt should be CreateTable, CreateIndex, CreateChangeStream or AlterTableAddForeignKey, but got '%s'", ddlstmt.SQL())
+			return nil, fmt.Errorf("unknown statement is specified: %s", ddlstmt.SQL())
 		default:
-			return nil, fmt.Errorf("stmt should be CreateTable, CreateIndex, CreateChangeStream or AlterTableAddForeignKey, but got '%s'", ddlstmt.SQL())
+			return nil, fmt.Errorf("unknown statement is specified: %s", ddlstmt.SQL())
 		}
 	}
 

--- a/v2/loader/source_test.go
+++ b/v2/loader/source_test.go
@@ -38,6 +38,8 @@ CREATE TABLE Simple (
 ) PRIMARY KEY(Id);
 CREATE INDEX SimpleIndex ON Simple(Value);
 CREATE UNIQUE INDEX SimpleIndex2 ON Simple(Id, Value);
+CREATE CHANGE STREAM EverythingStream
+  FOR ALL;
 `
 	testSchema2 = `
 CREATE TABLE MaxLengths (


### PR DESCRIPTION
We would like to skip when schema file includes `CREATE CHANGE STREAM` statements in v2.
Instead of https://github.com/cloudspannerecosystem/yo/pull/116 ,
I change code to skip when schema file includes statement which can parse and unsupported in yo v2 as v1 do.