### PR TITLE
Add installation method for Go 1.16+

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,14 @@ application is not officially supported as part of the Cloud Spanner product.
 
 ## Installation
 
+[Install Go](https://go.dev/doc/install) and run the following command.
+
 ```sh
-$ go get -u go.mercari.io/yo
+# For Go 1.16+
+go install go.mercari.io/yo@latest
+
+# For Go <1.16
+go get -u go.mercari.io/yo
 ```
 
 ## Quickstart


### PR DESCRIPTION
I added a installation command using `go install` to `README.md`.

I used [the README.md of spanner-cli](https://github.com/cloudspannerecosystem/spanner-cli/blob/master/README.md?plain=1#L15-L23) as a reference.