### PR TITLE
[v1] add allowCommitTimestamp field to models.Column

### DIFF
--- a/loaders/parser.go
+++ b/loaders/parser.go
@@ -132,13 +132,18 @@ func (s *SpannerLoaderFromDDL) ColumnList(name string) ([]*models.Column, error)
 		if _, ok := c.DefaultSemantics.(*ast.GeneratedColumnExpr); ok {
 			isGenerated = true
 		}
+		allowCommitTimestamp := false
+		if c.Options != nil {
+			allowCommitTimestamp = c.Options.AllowCommitTimestamp
+		}
 		cols = append(cols, &models.Column{
-			FieldOrdinal: i + 1,
-			ColumnName:   c.Name.Name,
-			DataType:     c.Type.SQL(),
-			NotNull:      c.NotNull,
-			IsPrimaryKey: pk,
-			IsGenerated:  isGenerated,
+			FieldOrdinal:         i + 1,
+			ColumnName:           c.Name.Name,
+			DataType:             c.Type.SQL(),
+			NotNull:              c.NotNull,
+			IsPrimaryKey:         pk,
+			IsGenerated:          isGenerated,
+			AllowCommitTimestamp: allowCommitTimestamp,
 		})
 	}
 

--- a/models/model.go
+++ b/models/model.go
@@ -28,12 +28,13 @@ type Table struct {
 
 // Column represents column info.
 type Column struct {
-	FieldOrdinal int    // field_ordinal
-	ColumnName   string // column_name
-	DataType     string // data_type
-	NotNull      bool   // not_null
-	IsPrimaryKey bool   // is_primary_key
-	IsGenerated  bool   // is_generated
+	FieldOrdinal         int    // field_ordinal
+	ColumnName           string // column_name
+	DataType             string // data_type
+	NotNull              bool   // not_null
+	IsPrimaryKey         bool   // is_primary_key
+	IsGenerated          bool   // is_generated
+	AllowCommitTimestamp bool   // allow_commit_timestamp
 }
 
 // Index represents an index.


### PR DESCRIPTION
## WHAT

add `AllowCommitTimestamp` field to `Column`

## WHY

It is useful to know whether the column is allowed to use `spanner.Timestamp` when using a custom template to generate fixtures.

**example**

As-Is

```go
tbl := &yo_gen.Todo{
    ID:          rand.Int64(),
    CreatedAt:   time.Now(),  // we cannot determine whether the column is allowed to use `spanner.CommitTimestamp`
}
```

To-Be

```go
tbl := &yo_gen.Todo{
    ID:          rand.Int64(),
    CreatedAt:   spanner.CommitTimestamp, 
}
```