### PR TITLE
Fix the release error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod download

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,7 +37,7 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "SNAPSHOT-{{ .Tag }}"
+  version_template: "SNAPSHOT-{{ .Tag }}"
 
 changelog:
   sort: asc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ builds:
         goarch: 386
 
 archives:
-  - format: tar.gz
+  - formats: tar.gz
     wrap_in_directory: true
     format_overrides:
       - goos: windows

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ archives:
     wrap_in_directory: true
     format_overrides:
       - goos: windows
-        format: zip
+        formats: zip
     name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     files:
       - LICENSE


### PR DESCRIPTION
- **ci: replace goreleaser's `--rm-dist` with `--clean`** : https://goreleaser.com/deprecations/#-rm-dist
- **chore: fix a goreleaser's warning** : set `version: 2` https://goreleaser.com/blog/goreleaser-v2/?h=#upgrading
- **chore: fix goreleaser's warning** https://goreleaser.com/deprecations/#snapshotname_template
- **chore: fix goreleaser's warning** https://goreleaser.com/deprecations/#archivesformat
- **chore: fix goreleaser's warning** https://goreleaser.com/deprecations/#archivesformat_overridesformat

Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/

---

At v0.6.0, no asset was released.

https://github.com/cloudspannerecosystem/yo/releases/tag/v0.6.0

<img width="289" alt="image" src="https://github.com/user-attachments/assets/c8a36b56-380f-4436-8c7a-981841cc409f" />

The release failed.

https://github.com/cloudspannerecosystem/yo/actions/runs/13513867624/job/37758951663

```
Run goreleaser/goreleaser-action@v2
Downloading https://github.com/goreleaser/goreleaser/releases/download/v2.7.0/goreleaser_Linux_x86_64.tar.gz
Extracting GoReleaser
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/437467ba-f059-44a6-b0be-fc4143f2621d -f /home/runner/work/_temp/b58e260b-073f-40a6-b84b-b1eaff94267a
GoReleaser latest installed successfully
v0.6.0 tag found for commit '297189b'
/opt/hostedtoolcache/goreleaser-action/2.7.0/x64/goreleaser release --rm-dist
  ⨯ command failed                                   error=unknown flag: --rm-dist
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.7.0/x64/goreleaser' failed with exit code 1
```

This pull request fixes GoReleaser's deprecation warnings.

## Before

```console
$ git rev-parse HEAD
42672b3e52c24281c68f84db952206bb6033e76a
```

```console
$ goreleaser check
  • only  version: 2  configuration files are supported, yours is  version: 0 , please update your configuration
  • checking                                 path=.goreleaser.yml
  • DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
  • DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
  • DEPRECATED:  archives.format_overrides.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```

## After

```console
$ goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```

```console
$ goreleaser release --snapshot --clean
  • skipping announce, publish, and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=8eed343809b70a196589ee9d6bd56e6243269606 branch=fix-goreleaser current_tag=v0.6.0 previous_tag=v0.5.7 dirty=false
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=SNAPSHOT-v0.6.0
  • running before hooks
    • running                                        hook=go mod download
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/yo_darwin_amd64_v1/yo
    • building                                       binary=dist/yo_linux_arm64_v8.0/yo
    • building                                       binary=dist/yo_windows_386_sse2/yo.exe
    • building                                       binary=dist/yo_linux_arm_6/yo
    • building                                       binary=dist/yo_linux_amd64_v1/yo
    • building                                       binary=dist/yo_darwin_arm64_v8.0/yo
    • building                                       binary=dist/yo_windows_arm64_v8.0/yo.exe
    • building                                       binary=dist/yo_windows_amd64_v1/yo.exe
    • building                                       binary=dist/yo_linux_386_sse2/yo
    • building                                       binary=dist/yo_windows_arm_6/yo.exe
    • took: 59s
  • archives
    • archiving                                      name=dist/yo-SNAPSHOT-v0.6.0-windows-amd64.zip
    • archiving                                      name=dist/yo-SNAPSHOT-v0.6.0-windows-arm64.zip
    • archiving                                      name=dist/yo-SNAPSHOT-v0.6.0-linux-armv6.tar.gz
    • archiving                                      name=dist/yo-SNAPSHOT-v0.6.0-linux-arm64.tar.gz
    • archiving                                      name=dist/yo-SNAPSHOT-v0.6.0-linux-amd64.tar.gz
    • archiving                                      name=dist/yo-SNAPSHOT-v0.6.0-linux-386.tar.gz
    • archiving                                      name=dist/yo-SNAPSHOT-v0.6.0-darwin-arm64.tar.gz
    • archiving                                      name=dist/yo-SNAPSHOT-v0.6.0-darwin-amd64.tar.gz
    • archiving                                      name=dist/yo-SNAPSHOT-v0.6.0-windows-386.zip
    • archiving                                      name=dist/yo-SNAPSHOT-v0.6.0-windows-armv6.zip
  • calculating checksums
  • writing artifacts metadata
  • release succeeded after 1m9s
  • thanks for using GoReleaser!
```