### PR TITLE
revert allow commitment timestamp

### DIFF
--- a/loaders/parser.go
+++ b/loaders/parser.go
@@ -132,18 +132,13 @@ func (s *SpannerLoaderFromDDL) ColumnList(name string) ([]*models.Column, error)
 		if _, ok := c.DefaultSemantics.(*ast.GeneratedColumnExpr); ok {
 			isGenerated = true
 		}
-		allowCommitTimestamp := false
-		if c.Options != nil {
-			allowCommitTimestamp = c.Options.AllowCommitTimestamp
-		}
 		cols = append(cols, &models.Column{
-			FieldOrdinal:         i + 1,
-			ColumnName:           c.Name.Name,
-			DataType:             c.Type.SQL(),
-			NotNull:              c.NotNull,
-			IsPrimaryKey:         pk,
-			IsGenerated:          isGenerated,
-			AllowCommitTimestamp: allowCommitTimestamp,
+			FieldOrdinal: i + 1,
+			ColumnName:   c.Name.Name,
+			DataType:     c.Type.SQL(),
+			NotNull:      c.NotNull,
+			IsPrimaryKey: pk,
+			IsGenerated:  isGenerated,
 		})
 	}
 

--- a/loaders/parser.go
+++ b/loaders/parser.go
@@ -132,21 +132,10 @@ func (s *SpannerLoaderFromDDL) ColumnList(name string) ([]*models.Column, error)
 		if _, ok := c.DefaultSemantics.(*ast.GeneratedColumnExpr); ok {
 			isGenerated = true
 		}
-
 		allowCommitTimestamp := false
 		if c.Options != nil {
-			for _, r := range c.Options.Records {
-				if r.Name.Name == "allow_commit_timestamp" {
-					boolLiteral, ok := r.Value.(*ast.BoolLiteral)
-					if !ok {
-						return nil, fmt.Errorf("the type of 'allow_commit_timestamp' should be 'bool', but got '%T'", r.Value)
-					}
-					allowCommitTimestamp = boolLiteral.Value
-					break
-				}
-			}
+			allowCommitTimestamp = c.Options.AllowCommitTimestamp
 		}
-
 		cols = append(cols, &models.Column{
 			FieldOrdinal:         i + 1,
 			ColumnName:           c.Name.Name,

--- a/models/model.go
+++ b/models/model.go
@@ -28,13 +28,12 @@ type Table struct {
 
 // Column represents column info.
 type Column struct {
-	FieldOrdinal         int    // field_ordinal
-	ColumnName           string // column_name
-	DataType             string // data_type
-	NotNull              bool   // not_null
-	IsPrimaryKey         bool   // is_primary_key
-	IsGenerated          bool   // is_generated
-	AllowCommitTimestamp bool   // allow_commit_timestamp
+	FieldOrdinal int    // field_ordinal
+	ColumnName   string // column_name
+	DataType     string // data_type
+	NotNull      bool   // not_null
+	IsPrimaryKey bool   // is_primary_key
+	IsGenerated  bool   // is_generated
 }
 
 // Index represents an index.


### PR DESCRIPTION
There is an issue at https://github.com/cloudspannerecosystem/yo/issues/159, and it is difficult to make this feature work when generating from the Spanner itself.
We need to reconsider how to implement it.