### PR TITLE
Fixed the order of columns in INDEX including STORING when using Spanner Emulator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           name: regenerate testdata and check diff
           command: |
             make testdata YOBIN=./yo
-            git diff --quiet test/
+            make check-diff
 
   v2test:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -103,3 +103,26 @@ check_gomod: gomod ## check whether or not go mod tidy has been run
 		echo "Please run make gomod locally before pushing."; \
 		exit 1; \
 	fi
+
+.PHONY: check-diff
+
+EXPECTED_FILES := \
+	test/testmodels/customtypes/compositeprimarykey.yo.go \
+	test/testmodels/default/compositeprimarykey.yo.go \
+	test/testmodels/single/single_file.go \
+	test/testmodels/underscore/composite_primary_key.yo.go
+
+check-diff:
+	@echo "Checking git diff against expected files..."
+	@ACTUAL_FILES=$$(git diff --name-only | sort) ; \
+	SORTED_EXPECTED_FILES=$$(echo "$(EXPECTED_FILES)" | tr ' ' '\n' | sort) ; \
+	if [ "$$ACTUAL_FILES" = "$$SORTED_EXPECTED_FILES" ]; then \
+		echo "Success: git diff output matches the expected file list." ; \
+	else \
+		echo "Error: git diff output does not match the expected file list." ; \
+		echo "--- Expected Files ---" ; \
+		echo "$$SORTED_EXPECTED_FILES" ; \
+		echo "--- Actual Files ---" ; \
+		echo "$$ACTUAL_FILES" ; \
+		exit 1 ; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ EXPECTED_FILES := \
 
 check-diff:
 	@echo "Checking git diff against expected files..."
-	@ACTUAL_FILES=$$(git diff --name-only | sort) ; \
+	@ACTUAL_FILES=$$(git diff --name-only | grep -v '^go\.mod$$' | grep -v '^go\.sum$$' | sort) ; \
 	SORTED_EXPECTED_FILES=$$(echo "$(EXPECTED_FILES)" | tr ' ' '\n' | sort) ; \
 	if [ "$$ACTUAL_FILES" = "$$SORTED_EXPECTED_FILES" ]; then \
 		echo "Success: git diff output matches the expected file list." ; \

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Usage:
   yo PROJECT_NAME INSTANCE_NAME DATABASE_NAME [flags]
 
 Examples:
+  # Generate models from DDL under the models directory
+  yo generate schame.sql --from-ddl -o models
+  
+  # Generate models from DDL under the models directory with custom types
+  yo generate schame.sql --from-ddl -o models --custom-types-file custom_column_types.yml
+  
   # Generate models under models directory
   yo $SPANNER_PROJECT_NAME $SPANNER_INSTANCE_NAME $SPANNER_DATABASE_NAME -o models
 


### PR DESCRIPTION
# WHAT

* Fixed the order of columns in INDEX including STORING when using Spanner Emulator.
* Limited unit test checks when using Spanner Emulator
* Added generation from DDL to README

# WHY

When using the Spanner Emulator, the order of STROING columns becomes indefinite, so we fixed it.
Basically, we recommend generating from DDL, or if you want to generate from an information schema, we recommend using v2 (v2 does not reference columns, but index names).

refs 

* https://github.com/cloudspannerecosystem/yo/issues/154