### PR TITLE
add .PHONY to commands in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ all: build
 build: regen ## build yo command and regenerate template bin
 	go build
 
+.PHONY: regen
 regen: tplbin/templates.go ## regenerate template bin
 
 deps:
@@ -61,25 +62,31 @@ testdata/customtypes:
 	rm -rf test/testmodels/customtypes && mkdir -p test/testmodels/customtypes
 	$(YOBIN) $(SPANNER_PROJECT_NAME) $(SPANNER_INSTANCE_NAME) $(SPANNER_DATABASE_NAME) --custom-types-file test/testdata/custom_column_types.yml --out test/testmodels/customtypes/
 
+.PHONY: testdata-from-ddl
 testdata-from-ddl:
 	$(MAKE) -j4 testdata-from-ddl/default testdata-from-ddl/underscore testdata-from-ddl/customtypes testdata-from-ddl/single
 
+.PHONY: testdata-from-ddl/default
 testdata-from-ddl/default:
 	rm -rf test/testmodels/default && mkdir -p test/testmodels/default
 	$(YOBIN) generate ./test/testdata/schema.sql --from-ddl --package models --out test/testmodels/default/
 
+.PHONY: testdata-from-ddl/underscore
 testdata-from-ddl/underscore:
 	rm -rf test/testmodels/underscores && mkdir -p test/testmodels/underscores
 	$(YOBIN) generate ./test/testdata/schema.sql --from-ddl --package models --underscore --out test/testmodels/underscores/
 
+.PHONY: testdata-from-ddl/single
 testdata-from-ddl/single:
 	rm -rf test/testmodels/single && mkdir -p test/testmodels/single
 	$(YOBIN) generate ./test/testdata/schema.sql --from-ddl --out test/testmodels/single/single_file.go --single-file
 
+.PHONY: testdata-from-ddl/customtypes
 testdata-from-ddl/customtypes:
 	rm -rf test/testmodels/customtypes && mkdir -p test/testmodels/customtypes
 	$(YOBIN) generate ./test/testdata/schema.sql --from-ddl --custom-types-file test/testdata/custom_column_types.yml --out test/testmodels/customtypes/
 
+.PHONY: recreate-templates
 recreate-templates:: ## recreate templates
 	rm -rf templates && mkdir templates
 	$(YOBIN) create-template --template-path templates


### PR DESCRIPTION
## WHAT
some CI checks were always pass because there are already generated artifacts and make command skipped it.
[example](https://app.circleci.com/pipelines/github/cloudspannerecosystem/yo/446/workflows/6318b871-643a-40df-b4e2-b12a38566d77/jobs/1135)

So I added `.PHONY` to force execute all command to generate.

I agreeded to CLA.
https://cla.developers.google.com/
